### PR TITLE
Lock buttons after submitting and restore after a delay

### DIFF
--- a/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix.csproj
+++ b/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net35</TargetFramework>
+    <AssemblyName>BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix</AssemblyName>
+    <Description>EquipmentMenuFix</Description>
+    <Version>1.0.0</Version>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.Core" Version="5.*" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
+    <PackageReference Include="UnityEngine.Modules" Version="5.6.7" IncludeAssets="compile" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\lib\SteamRelease\Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>..\lib\UnityEngine\UnityEngine.UI.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy /Y /Q /C /I &quot;$(OutDir)&quot; &quot;..\$(OutDir)\$(TargetName)\&quot;" />
+  </Target>
+</Project>

--- a/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/EquipmentMenuSlotButtonSelect_Awake.cs
+++ b/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/EquipmentMenuSlotButtonSelect_Awake.cs
@@ -1,0 +1,35 @@
+﻿using HarmonyLib;
+using UnityEngine.UI;
+
+namespace BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix.HarmonyPatches
+{
+	[HarmonyPatch(typeof(EquipmentMenuSlotButtonSelect), "Awake")]
+	public class EquipmentMenuSlotButtonSelect_Awake
+	{
+		// Set the disabled state to be the same as the normal state.
+		public static void Postfix(EquipmentMenuSlotButtonSelect __instance)
+		{
+			var button = __instance.GetComponent<Button>();
+
+			if (button)
+			{
+				if (button.transition == Selectable.Transition.SpriteSwap)
+				{
+					var spriteState = button.spriteState;
+
+					spriteState.disabledSprite = button.image.sprite;
+
+					button.spriteState = spriteState;
+				}
+				else if (button.transition == Selectable.Transition.ColorTint)
+				{
+					var colorBlock = button.colors;
+
+					colorBlock.disabledColor = colorBlock.normalColor;
+
+					button.colors = colorBlock;
+				}
+			}
+		}
+	}
+}

--- a/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/EquipmentMenuSlotButtonSelect_OnSelect.cs
+++ b/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/EquipmentMenuSlotButtonSelect_OnSelect.cs
@@ -1,0 +1,47 @@
+﻿using HarmonyLib;
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix.HarmonyPatches
+{
+	[HarmonyPatch(typeof(EquipmentMenuSlotButtonSelect), "OnSelect", new Type[] { typeof(BaseEventData) })]
+	public class EquipmentMenuSlotButtonSelect_OnSelect
+	{
+		// Prevent processing when button is not interactable.
+		public static bool Prefix(EquipmentMenuSlotButtonSelect __instance, BaseEventData eventData)
+		{
+			try
+			{
+				var button = __instance.GetComponent<Button>();
+
+				if (!button)
+				{
+					return true;
+				}
+
+				if (button && !button.interactable)
+				{
+					return false;
+				}
+
+				if (button)
+				{
+					var canvasGroup = button.transform.parent?.parent?.GetComponent<CanvasGroup>();
+
+					if (canvasGroup && !canvasGroup.interactable)
+					{
+						return false;
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine(ex);
+			}
+
+			return true;
+		}
+	}
+}

--- a/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/Interaction_CloseMenu.cs
+++ b/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/Interaction_CloseMenu.cs
@@ -1,0 +1,41 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix.HarmonyPatches
+{
+	[HarmonyPatch(typeof(Interaction), "CloseMenu")]
+	public class Interaction_CloseMenu
+	{
+		// Make all concerned buttons non interactable, and restore them after a delay.
+		public static void Prefix(Interaction __instance
+			, ref EquipmentMenu ___equipmentMenuScript
+			)
+		{
+			if (!___equipmentMenuScript.buttonLock)
+			{
+				Console.WriteLine("Patching exit button");
+
+				var canvasGroup = ___equipmentMenuScript.GetComponent<CanvasGroup>();
+
+				if (canvasGroup)
+				{
+					canvasGroup.interactable = false;
+
+					__instance.StartCoroutine(ClosingMenu(___equipmentMenuScript, canvasGroup));
+				}
+			}
+		}
+
+		public static IEnumerator ClosingMenu(EquipmentMenu equipment, CanvasGroup canvasGroup)
+		{
+			yield return new WaitForSeconds(0.4f);
+			yield return new WaitForSeconds(0.5f);
+
+			System.Console.WriteLine("Restoring buttons");
+
+			canvasGroup.interactable = true;
+		}
+	}
+}

--- a/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/InventoryTabButtons_KeysButton.cs
+++ b/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/InventoryTabButtons_KeysButton.cs
@@ -1,0 +1,40 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix.HarmonyPatches
+{
+	[HarmonyPatch(typeof(InventoryTabButtons), "KeysButton")]
+	public class InventoryTabButtons_KeysButton
+	{
+		// Make all concerned buttons non interactable, and restore them after a delay.
+		public static void Prefix(InventoryTabButtons __instance
+			, ref EquipmentMenu ___equipment
+			)
+		{
+			if (!___equipment.buttonLock)
+			{
+				Console.WriteLine("Patching keys button");
+
+				var canvasGroup = ___equipment.GetComponent<CanvasGroup>();
+
+				if (canvasGroup)
+				{
+					canvasGroup.interactable = false;
+
+					__instance.StartCoroutine(RestoreInteraction(___equipment, canvasGroup));
+				}
+			}
+		}
+
+		public static IEnumerator RestoreInteraction(EquipmentMenu equipment, CanvasGroup canvasGroup)
+		{
+			yield return new WaitForSeconds(0.5f);
+
+			Console.WriteLine("Restoring buttons");
+
+			canvasGroup.interactable = true;
+		}
+	}
+}

--- a/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/InventoryTabButtons_OpenHelpMenu.cs
+++ b/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/InventoryTabButtons_OpenHelpMenu.cs
@@ -1,0 +1,40 @@
+using HarmonyLib;
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix.HarmonyPatches
+{
+	[HarmonyPatch(typeof(InventoryTabButtons), "OpenHelpMenu")]
+	public class InventoryTabButtons_OpenHelpMenu
+	{
+		// Make all concerned buttons non interactable, and restore them after a delay.
+		public static void Prefix(InventoryTabButtons __instance
+			, ref EquipmentMenu ___equipment
+			)
+		{
+			if (!___equipment.buttonLock)
+			{
+				Console.WriteLine("Patching help button");
+
+				var canvasGroup = ___equipment.GetComponent<CanvasGroup>();
+
+				if (canvasGroup)
+				{
+					canvasGroup.interactable = false;
+
+					__instance.StartCoroutine(RestoreInteraction(___equipment, canvasGroup));
+				}
+			}
+		}
+
+		public static IEnumerator RestoreInteraction(EquipmentMenu equipment, CanvasGroup canvasGroup)
+		{
+			yield return new WaitForSeconds(0.5f);
+
+			Console.WriteLine("Restoring buttons");
+
+			canvasGroup.interactable = true;
+		}
+	}
+}

--- a/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/InventoryTabButtons_OpenMapMenu.cs
+++ b/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/HarmonyPatches/InventoryTabButtons_OpenMapMenu.cs
@@ -1,0 +1,40 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix.HarmonyPatches
+{
+	[HarmonyPatch(typeof(InventoryTabButtons), "OpenMapMenu")]
+	public class InventoryTabButtons_OpenMapMenu
+	{
+		// Make all concerned buttons non interactable, and restore them after a delay.
+		public static void Prefix(InventoryTabButtons __instance
+			, ref EquipmentMenu ___equipment
+			)
+		{
+			if (!___equipment.buttonLock)
+			{
+				Console.WriteLine("Patching map button");
+
+				var canvasGroup = ___equipment.GetComponent<CanvasGroup>();
+
+				if (canvasGroup)
+				{
+					canvasGroup.interactable = false;
+
+					__instance.StartCoroutine(RestoreInteraction(___equipment, canvasGroup));
+				}
+			}
+		}
+
+		public static IEnumerator RestoreInteraction(EquipmentMenu equipment, CanvasGroup canvasGroup)
+		{
+			yield return new WaitForSeconds(0.5f);
+
+			Console.WriteLine("Restoring buttons");
+
+			canvasGroup.interactable = true;
+		}
+	}
+}

--- a/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/NuGet.Config
+++ b/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/Plugin.cs
+++ b/BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix/Plugin.cs
@@ -1,0 +1,26 @@
+﻿using BepInEx;
+using HarmonyLib;
+using System;
+
+namespace BepInEx5Plugins.Ash.Alisa.EquipmentMenuFix
+{
+	[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+	public class Plugin : BaseUnityPlugin
+	{
+		private void Awake()
+		{
+			try
+			{
+				Logger.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
+
+				var harmony = new Harmony(Info.Metadata.GUID);
+
+				harmony.PatchAll();
+			}
+			catch (Exception exception)
+			{
+				Console.WriteLine(exception);
+			}
+		}
+	}
+}


### PR DESCRIPTION
The new behaviour is not 1:1 to the original game. The buttons should be separately handled so that the sprite of the currently selected (but non-interactable) button would still be shown as highlighted.